### PR TITLE
Replace rather than update latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,6 +262,18 @@ jobs:
           prerelease: false
           name: ${{ needs.check-version.outputs.version }}
           generate_release_notes: true
+      - name: Delete release latest
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { owner, repo } = context.repo
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: 'tags/latest' })
+            }
+            catch (err) {
+              if (err.status !== 422) throw err
+            }           
       - name: Build release latest
         uses: softprops/action-gh-release@v1
         with:

--- a/helm/vitalam-ipfs/Chart.yaml
+++ b/helm/vitalam-ipfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vitalam-ipfs
-appVersion: '1.0.1'
+appVersion: '1.0.2'
 description: A Helm chart for vitalam-ipfs
-version: '1.0.1'
+version: '1.0.2'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/vitalam-ipfs/values.yaml
+++ b/helm/vitalam-ipfs/values.yaml
@@ -3,5 +3,5 @@ config:
 image:
   repository: ghcr.io/digicatapult/vitalam-ipfs
   pullPolicy: IfNotPresent
-  tag: 'v1.0.1'
+  tag: 'v1.0.2'
   pullSecrets: ['ghcr-digicatapult']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@digicatapult/vitalam-ipfs",
-  "version": "1.0.1",
+  "name": "@digicaapult/vitalam-ipfs",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/vitalam-ipfs",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/vitalam-ipfs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Service for WASP",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Uses [github-script](https://github.com/actions/github-script) to delete `tags/latest` so we get a new `latest` release that matches our most recent release.
